### PR TITLE
Override nsIAlertsService to allow addons to show native notifications

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -39,14 +39,15 @@ AlertsService.prototype = {
     QueryInterface: XPCOMUtils.generateQI([Ci.nsIAlertsService]),
 
     
-    showAlertNotification: function GNotifier_AlertsService_showAlertNotification(imageUrl, title, text, textClickable, cookie, alertListener, name)
+    showAlertNotification: function GNotifier_AlertsService_showAlertNotification(
+    		imageUrl, title, text, textClickable, cookie, alertListener, name
+    )
     {
     	//TODO: Support textClickable (Yes its possible using a button...)
-    	var iconFile = null;
-    	function GNotifier_AlertsService_showAlertNotification_cb()
+    	function GNotifier_AlertsService_showAlertNotification_cb(iconPath)
     	{
     		// Display notification
-    		notify2(iconFile.path, title, text, name);
+    		notify2(iconPath, title, text, name);
     		
     		//TODO: Call the callback once the alert is actually finished...
     		if(typeof(alertListener) == "function") {
@@ -57,38 +58,44 @@ AlertsService.prototype = {
 		try {
 			// Try using a local icon file URL
 			var imageURI = NetUtil.newURI(imageUrl);
-			iconFile = imageURI.QueryInterface(Ci.nsIFileURL).file;
-			abc();
+			var iconFile = imageURI.QueryInterface(Ci.nsIFileURL).file;
+			
 			// Success!
-			GNotifier_AlertsService_showAlertNotification_cb();
+			GNotifier_AlertsService_showAlertNotification_cb(iconFile.path);
 		} catch(e) {
-			// Create temporary local file
-			// (Required since I don't want to manually
-			//  populate a GdkPixbuf...)
-			iconFile = FileUtils.getFile("TmpD", [".gnotifier.tmp"]);
-			iconFile.createUnique(
-					Ci.nsIFile.NORMAL_FILE_TYPE,
-					FileUtils.PERMS_FILE
-			);
-	
-			// Copy data from original icon to local file
-			var imageFile = NetUtil.newChannel(imageUrl);
-			NetUtil.asyncFetch(imageFile, function(imageStream)
-			{
+			try {
+				// Create temporary local file
+				// (Required since I don't want to manually
+				//  populate a GdkPixbuf...)
+				var iconFile = FileUtils.getFile("TmpD", [".gnotifier.tmp"]);
+				iconFile.createUnique(
+						Ci.nsIFile.NORMAL_FILE_TYPE,
+						FileUtils.PERMS_FILE
+				);
 				var iconStream = FileUtils.openSafeFileOutputStream(iconFile);
-				NetUtil.asyncCopy(imageStream, iconStream, function()
+	
+				// Copy data from original icon to local file
+				var imageFile = NetUtil.newChannel(imageUrl);
+				NetUtil.asyncFetch(imageFile, function(imageStream)
 				{
-					// Show notification with copied icon file
-					GNotifier_AlertsService_showAlertNotification_cb();
+					NetUtil.asyncCopy(imageStream, iconStream, function()
+					{
+						// Show notification with copied icon file
+						GNotifier_AlertsService_showAlertNotification_cb(
+								imageFile.path
+						);
 					
-					// Close streams
-					iconStream.close();
-					imageStream.close();
+						// Close streams
+						iconStream.close();
+						imageStream.close();
 					
-					// Delete icon file
-					iconFile.remove(false);
+						// Delete icon file
+						iconFile.remove(false);
+					});
 				});
-			});
+			} catch(e) {
+				GNotifier_AlertsService_showAlertNotification_cb(imageUrl);
+			}
 		}
     }
 };


### PR DESCRIPTION
This addon should also replace nsIAlertsService so that notifications shown by addons either using nsIAlertsService directly or through sdk/notifications.js Addon-SDK library get displayed correctly. Unfortunately nsIAlertsService does not seem to provide observers and disabling prefs (like download manager does), therefor a class factory override has to be used.
