### PR TITLE
bump Firefox compatibility

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -13,7 +13,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>21.0</em:minVersion>
-        <em:maxVersion>40.*</em:maxVersion>
+        <em:maxVersion>41.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     


### PR DESCRIPTION
As far as I could test, GNotifier works as expected with the recent Firefox version 41, so I recommend to increase the maximum compatible version for Firefox.