### PR TITLE
bump Firefox compatibility

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -13,7 +13,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>21.0</em:minVersion>
-        <em:maxVersion>41.*</em:maxVersion>
+        <em:maxVersion>42.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     


### PR DESCRIPTION
Like previously seen in #66, with a new Firefox release comes the time to update the compatible version range for this Add-On. Once again it already works flawlessly with version 42, as tested via [a Mozilla demo tool](https://developer.cdn.mozilla.net/media/uploads/demos/e/l/elfoxero/c17223c414d8ddafb7808972b5617d9e/html5-notifications_1400214081_demo_package/index.html), so the only thing left to do is increasing the maximum compatible version in the _install.rdf_ file.