### PR TITLE
Customizable notifications for Thunderbird

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -14,7 +14,7 @@
     "description": "GNotifier integrates Firefox/Thunderbird's notifications with the native notification system. It supports most Linux desktops, Windows 8.1 and 10",
     "unpack": true,
     "main": "lib/main.js",
-    
+
     "preferences": [
         {
             "name": "engine",
@@ -101,6 +101,28 @@
             "title": "Custom command (Experimental)",
             "description": "Defines custom shell command that will be executed. This option is applicable only if engine option is set to 'Custom' value. Note that notification title, text or image you can pass to command with following variables: %title, %text, %image.",
             "type": "string",
+            "value": ""
+        },
+        {
+            "name": "emailTitleFormat",
+            "title": "Title for E-mail notifications (Thunderbird only)",
+            "description": "%s: Subject, %a: Sender (Name <E-mail>), %m: Sender E-mail, %n: Sender Name, %f: Folder, %v: Server, %k: Size, %u: Account, %b: Body excerpt, %%: %",
+            "type": "string",
+            "value": "%a"
+        },
+        {
+            "name": "emailTextFormat",
+            "title": "Text for E-mail notifications (Thunderbird only)",
+            "description": "%s: Subject, %a: Sender (Name <E-mail>), %m: Sender E-mail, %n: Sender Name, %f: Folder, %v: Server, %k: Size, %u: Account, %b: Body excerpt, %%: %, \\n: Newline",
+            "type": "string",
+            "value": "%s"
+        },
+        {
+            "name": "test",
+            "title": "Test Notification (Thunderbird only)",
+            "label": "Test notification",
+            "description": "Select a message from any folder, then come back and click on 'Test notification'",
+            "type": "control",
             "value": ""
         }
     ]


### PR DESCRIPTION
I added the option to customize the notification content (for e-mails only) in Thunderbird. Basically, now there's two prefs, one to customize the title and another for the body of the notification. There you can set a string which may contain any of the following placeholders:
```
%s: Subject
%a: Sender (Name <E-mail>)
%m: Sender E-mail
%n: Sender Name
%f: Folder name
%v: Server address
%k: Message size
%u: Account name
%b: Body excerpt (first 80 characters)
%%: % symbol,
\n: Newline (only for notification body)
```

I also added a button to test the notification system (especially useful for this new feature), that uses the currently selected e-mail (in the main window/tab) as example.

Just in case, a few comments for clarification:

I used `gHeaderParser.parseDecodedHeader(message.mime2DecodedAuthor)` to separate sender name from sender email, which seems better than using regex.

I split `showNewMessageNotification` into `showNewRSSNotification` and `showNewEmailNotification`, since now they are completely different. Maybe they could be merged again sometime if we enable notification customization for RSS as well.
    
The `format` function receives a callback because obtaining the body of a message is asynchronous. From that I infer that it's not immediate, therefore I only use it if necessary (i.e. the format string actually contains %b). All the callback hassle in `showNewMessageNotification` and `format` is because of that. Maybe there's a prettier way to do it?