### PR TITLE
add buttons to Thunderbird notifications

### DIFF
--- a/source/lib/thunderbird.js
+++ b/source/lib/thunderbird.js
@@ -20,7 +20,7 @@ function showSimpleNewMessageNotification(isRSS) {
     var title = isRSS ? _("New_article") : _("New_message");
     var text = _("Number_of_unread_messages") + " " + count;
 
-    showNotification(title, text);
+    showNotification(title, text, null);
 }
 
 function showNewRSSNotification(message) {
@@ -37,7 +37,7 @@ function showNewRSSNotification(message) {
     var title = _("New_article_from") + " " + author;
     var text = message.mime2DecodedSubject;
 
-    showNotification(title, text);
+    showNotification(title, text, message);
 }
 
 function showNewEmailNotification(message) {
@@ -49,13 +49,13 @@ function showNewEmailNotification(message) {
     var title = string;
     format(message, textFormat, function(string){
       var text = string;
-      showNotification(title, text);
+      showNotification(title, text, message);
     });
   });
 
 }
 
-function showNotification(title, text){
+function showNotification(title, text, message){
 
     var utils = require('./utils');
 
@@ -137,7 +137,7 @@ function testNotification(){
   if(win.gFolderDisplay.selectedMessage){
     showNewEmailNotification(win.gFolderDisplay.selectedMessage);
   } else {
-    showNotification("GNotifier test", "You need to select a message to test this feature");
+    showNotification("GNotifier test", "You need to select a message to test this feature", null);
   }
 }
 

--- a/source/lib/thunderbird.js
+++ b/source/lib/thunderbird.js
@@ -59,13 +59,18 @@ function showNotification(title, text, message){
 
     var utils = require('./utils');
 
-    // if linux => doing unclickable notification, so without actionList
     var system = require("sdk/system");
     var sps = require("sdk/simple-prefs").prefs;
-    if (sps['engine'] == 1 && system.platform === "linux") {
+    if (sps['engine'] == 1 && system.platform === "linux" && notifApi.checkButtonsSupported()) {
         var notifApi = require('./linux');
-        if (notifApi.notifyWithActions(utils.getIcon(), title, text, system.name, null, null))
-          return;
+        if (notifApi.notifyWithActions(utils.getIcon(), title, text, system.name, null,
+                    message ? [{
+                        label: _("open"),
+                        handler: function() {
+                            display(message);
+                        }
+                    }] : null))
+            return;
     }
 
     var notifications = require("sdk/notifications");
@@ -75,6 +80,15 @@ function showNotification(title, text, message){
         iconURL: utils.getIcon(),
     });
 
+}
+
+// Display a given message.
+function display(message) {
+    Cc['@mozilla.org/appshell/window-mediator;1']
+        .getService(Ci.nsIWindowMediator)
+        .getMostRecentWindow("mail:3pane")
+        .document.getElementById("tabmail")
+        .openTab("message", {msgHdr: message});
 }
 
 function format(message, format, callback){

--- a/source/lib/thunderbird.js
+++ b/source/lib/thunderbird.js
@@ -82,13 +82,25 @@ function showNotification(title, text, message){
 
 }
 
-// Display a given message.
+// Display a given message. Heavily inspired by
+// https://developer.mozilla.org/docs/Mozilla/Thunderbird/Content_Tabs
 function display(message) {
-    Cc['@mozilla.org/appshell/window-mediator;1']
+    // Try opening new tabs in an existing 3pane window
+    let mail3PaneWindow = Cc["@mozilla.org/appshell/window-mediator;1"]
         .getService(Ci.nsIWindowMediator)
-        .getMostRecentWindow("mail:3pane")
-        .document.getElementById("tabmail")
-        .openTab("message", {msgHdr: message});
+        .getMostRecentWindow("mail:3pane");
+    if (mail3PaneWindow) {
+        var tabmail = mail3PaneWindow.document.getElementById("tabmail");
+        if (tabmail) {
+            tabmail.openTab("message", {msgHdr: message});
+            mail3PaneWindow.focus();
+            return
+        }
+    }
+
+    // If no window to open in can be found, fall back
+    // to any window and spwan a new one from there.
+    require("sdk/window/utils").windows()[0].openDialog("chrome://messenger/content/messageWindow.xul", "_blank", "all,chrome,dialog=no,status,toolbar", message);
 }
 
 function format(message, format, callback){

--- a/source/lib/thunderbird.js
+++ b/source/lib/thunderbird.js
@@ -69,6 +69,11 @@ function showNotification(title, text, message){
                         handler: function() {
                             display(message);
                         }
+                    }, {
+                        label: _("Mark_as_read"),
+                        handler: function() {
+                            message.markRead(true);
+                        }
                     }] : null))
             return;
     }

--- a/source/locale/de.properties
+++ b/source/locale/de.properties
@@ -2,6 +2,7 @@ download_finished=Download abgeschlossen
 open=Öffnen
 Open_file=Datei öffnen
 Open_folder=Ordner öffnen
+Mark_as_read=Als gelesen markieren
 Number_of_unread_messages=Anzahl der ungelesenen Nachrichten:
 New_message=Neue Nachricht!
 New_message_from=Neue Nachricht von

--- a/source/locale/en.properties
+++ b/source/locale/en.properties
@@ -2,6 +2,7 @@ download_finished=Download complete
 open=Open
 Open_file=Open file
 Open_folder=Open folder
+Mark_as_read=Mark as read
 Number_of_unread_messages=Number of unread messages:
 New_message=New message!
 New_message_from=New message from


### PR DESCRIPTION
The Firefox notifications already have buttons to open downloaded file or folder. This patchset adds similar buttons to the mail notifications: One to display the message, and one to dismiss it as read immediately.

I developed this on gnome-shell 3.20. The buttons do something similar as requested in #35. For them to have an effect as well as a click to the notification area, the `clickHandler` and `actionsList` of the `notify` and `notifyWithActions` functions would have to be combined.