### PR TITLE
[RFC] expose close reason to handlers

### DIFF
--- a/source/lib/linux.js
+++ b/source/lib/linux.js
@@ -54,6 +54,7 @@ var g_signal_connect_data;
 var notify_get_server_info;
 var notify_get_server_caps;
 var notify_notification_add_action;
+var notify_notification_get_closed_reason;
 
 var c_close_handler = callbackFunType(handleClose);
 var c_action_handle = actionFunType(handleAction);
@@ -155,7 +156,8 @@ function handleClose(notification, data) {
     while (i > 0 && closedCallbackFunArray.length > 0) {
       i--;
       if (closedCallbackFunArray[i]["notification_id"] === notification_id) {
-        closedCallbackFunArray[i]["handler"]();
+        closedCallbackFunArray[i]["handler"](
+            notify_notification_get_closed_reason(notification));
         closedCallbackFunArray.splice(i, 1);
         break;
       }
@@ -250,6 +252,9 @@ linux.checkAvailable = function() {
           ctypes.default_abi, ctypes.void_t, struct_notification.ptr,
           ctypes.char.ptr, ctypes.char.ptr, ctypes.voidptr_t, ctypes.voidptr_t,
           ctypes.voidptr_t);
+        notify_notification_get_closed_reason = libc.declare(
+          "notify_notification_get_closed_reason",
+          ctypes.default_abi, ctypes.int, struct_notification.ptr);
 
         checkServerInfo();
         //console.log("Notify server name: " + checkServerInfo());

--- a/source/lib/main.js
+++ b/source/lib/main.js
@@ -73,7 +73,10 @@ function showDownloadCompleteNotification(path, dir, filename) {
         }
 
         // if success, return, if not trying standard notification
-        if (notifApi.notifyWithActions(utils.getIcon(), title, text, system.name, null, actions)) {
+        if (notifApi.notifyWithActions(utils.getIcon(), title, text, system.name,
+                    function(reason) {
+                        console.log(reason);
+                    }, actions)) {
             return;
         }
     }
@@ -167,7 +170,8 @@ AlertsService.prototype = {
         function GNotifier_AlertsService_showAlertNotification_cb(iconPath) {
           
             // Defing close handler
-            var closeHandler = function(){
+            var closeHandler = function(reason){
+                console.log(reason);
                 // Generating "alertfinished"
                 //console.log("Generating alertfinished");
                 if(alertListener && typeof(alertListener) == "object") {

--- a/source/lib/thunderbird.js
+++ b/source/lib/thunderbird.js
@@ -63,7 +63,10 @@ function showNotification(title, text, message){
     var sps = require("sdk/simple-prefs").prefs;
     var notifApi = require('./linux');
     if (sps['engine'] == 1 && system.platform === "linux" && notifApi.checkButtonsSupported()) {
-        if (notifApi.notifyWithActions(utils.getIcon(), title, text, system.name, null,
+        if (notifApi.notifyWithActions(utils.getIcon(), title, text, system.name,
+                    function(reason) {
+                        console.log(reason);
+                    },
                     message ? [{
                         label: _("open"),
                         handler: function() {


### PR DESCRIPTION
The code herein is far from complete and more of a work in progress. It did not work on my setup, however I hope it can be useful to other window managers, so I leave it here.

In trying to solve #35, I found that libnotify exposes a `closed-reason`. Hoping this would enable to tell apart a timeout from a click to the notification body, I implemented its passing to the close handlers. Then, I tested this on my GNOME Shell 3.20 and found the following values.

|interaction|reason|
|---|---|
|none (timeout)|2|
|clicked body|2|
|clicked button|2|
|clicked ✖ in top right|2|
|clicked ✖ in notification area<br><sup>Dismisses all notifications</sup>|2|
|Moved mouse over notification. <br><sub>Shell seems to interpret this as "seen" and</sub><br><sup>destroys notification as mouse leaves body</sup>|2|

Seems to be an extremely meaningful 2...

As GNOME seems to leave me with no chance to tell whether the notification was closed on purpose, I give up on this path and will have to be satisfied with the buttons.