### PR TITLE
update compatible Thunderbird version

### DIFF
--- a/source/install.rdf
+++ b/source/install.rdf
@@ -26,7 +26,7 @@
             <Description>
               <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
               <em:minVersion>24.1.1</em:minVersion>
-              <em:maxVersion>40.*</em:maxVersion>
+              <em:maxVersion>45.*</em:maxVersion>
             </Description>
           </em:targetApplication>
           


### PR DESCRIPTION
Thunderbird version 45 was recently released. Apparently, most versions before it were betas only and never hit distribution repositories. Despite the quite large change in number, the extension seems to work just fine.