### PR TITLE
Add support for Pale Moon 27.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Add-on for Firefox and Thunderbird. Replaces built-in notifications with the OS 
 
 ## Pale Moon
 
-The XPIs created with [cfx](https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/cfx) are named in the following convention: [gnotifier-cfx-X.X.X.xpi](https://github.com/mkiol/GNotifier/tree/master/xpi). They are compatible with Pale Moon and old versions of Firefox.
+The XPIs created with [cfx](https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/cfx) are named in the following convention: [gnotifier-cfx-X.X.X.xpi](https://github.com/mkiol/GNotifier/tree/master/xpi). They are compatible with Pale Moon and old versions of Firefox.  
+
+From Pale Moon 27.1 onwards, you can install the regular jpm-created XPIs normally.  
 
 ## License
 

--- a/source/install.rdf
+++ b/source/install.rdf
@@ -40,6 +40,14 @@
             </Description>
           </em:targetApplication>
 
+          <!-- Pale Moon -->
+          <em:targetApplication>
+            <Description>
+              <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
+              <em:minVersion>27.1.0b1</em:minVersion>
+              <em:maxVersion>*</em:maxVersion>
+            </Description>
+          </em:targetApplication>
 
           <em:contributor>Alexander Schlarb &lt;alexander1066@xmine128.tk&gt;</em:contributor>
 


### PR DESCRIPTION
Based on [PMkit documentation draft v1.1](http://developer.palemoon.org/Add-ons:Extensions/Jetpack), tested with [Pale Moon 27.1.2](http://palemoon.org) and GNotifier 1.9.9.