### PR TITLE
Remove 2 second delay if buffering is disabled

### DIFF
--- a/source/lib/thunderbird.js
+++ b/source/lib/thunderbird.js
@@ -39,9 +39,13 @@ function isFolderRSS(folder) {
 }
 
 function bufferMessageNotification(message) {
-  clearTimeout(timeoutID);
-  bufferedMessages.push(message);
-  timeoutID = setTimeout(()=>{showMessageNotificationFromBuffer();}, 2000);
+  if (sps.maxMessageBuffer == 0) {
+    setTimeout(()=>{showMessageNotification(message);}, 1);
+  } else {
+    clearTimeout(timeoutID);
+    bufferedMessages.push(message);
+    timeoutID = setTimeout(()=>{showMessageNotificationFromBuffer();}, 2000);
+  }
 
   // Debug
   //console.log("bufferMessageNotification");


### PR DESCRIPTION
If you have some other indicator of new messages besides the notification, for example the blue envelope in Ubuntu or TB's sound alert, they both arrive 2 seconds before GNotifier's notification.
That's because of notification buffering, but if it's disabled, then that 2 second delay is not really necessary.

About the solution: I had to put a timeout of 1ms because otherwise TB would start behaving erratically. It has something to do with `getMessageBody` in `format`, that apparently is not ready yet if called syncronously. The 1ms delay seems to solve it (I've been testing it for a week).

If there's a better way to solve this, feel free to change it.